### PR TITLE
Opp 52

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -35,8 +35,9 @@ url_repo_db = "http://localhost"
 repo_db_port = "8080"
 repo_db_path = "/bigdata/namespace/"
 
-# OAuth
-use_oauth = True
+# Standalone mode
+standalone = False
+
 # ssl, i.e. https
 use_ssl = True
 

--- a/documents/apiary/api.md
+++ b/documents/apiary/api.md
@@ -109,6 +109,86 @@ Capabilities/limitations of the service
                 }
             }
 
+# Group Namespace
+
+## Initialise Namespace resource [/v1/repository/repositories/{repository_id}/initialise]
+
++ Parameters
+    + repository_id: `4e605140414e60514041` (required, string)
+        Id of repository to initialise
+
+### Intitialise a Repository Namespace[POST]
+
+| OAuth Token Scope |
+| :----------       |
+| write             |
+
+#### Output
+| Property | Description               | Type   |
+| :------- | :----------               | :---   |
+| status   | The status of the request | number |
+
++ Request to intiialise repository namespace
+    + Headers
+
+            Authorization: Bearer [TOKEN]
+
++ Response 200 (application/json; charset=UTF-8)
+    + Headers
+
+            Access-Control-Allow-Origin: *
+
+    + Body
+
+            {
+                "status": 200
+            }
+
+
++ Request to intitialise repository namespace that has not been registered with accounts service
+    + Headers
+
+            Authorization: Bearer [TOKEN]
+            
++ Response 404 (application/json; charset=UTF-8)
+    + Headers
+
+            Access-Control-Allow-Origin: *
+
+    + Body
+
+            {
+                "status": 404,
+                "errors": [
+                    {
+                        "source": "repository",
+                        "message": "Not Found"
+                    }
+                ]
+            }
+
++ Request to intitialise repository namespace that has already been initialised
+    + Headers
+
+            Authorization: Bearer [TOKEN]
+            
++ Response 400 (application/json; charset=UTF-8)
+    + Headers
+
+            Access-Control-Allow-Origin: *
+
+    + Body
+
+            {
+                "status": 404,
+                "errors": [
+                    {
+                        "source": "repository",
+                        "message": "Namespace 4e605140414e60514041 already exists"
+                    }
+                ]
+            }
+
 # Group Assets
 
 ## Assets resource [/v1/repository/repositories/{repository_id}/assets]

--- a/repository/__init__.py
+++ b/repository/__init__.py
@@ -10,3 +10,5 @@
 __version__ = '1.0.9'
 
 from tornado.options import define
+
+define("standalone", help='Run service in standalone mode', default=False, type=bool)

--- a/repository/app.py
+++ b/repository/app.py
@@ -17,7 +17,7 @@ import koi
 
 from .controllers import (
     agreements_handler, assets_handler, capabilities_handler,
-    offers_handler, sets_handler, root_handler)
+    offers_handler, namespace_handler, sets_handler, root_handler)
 
 from . import __version__
 from . import audit
@@ -29,6 +29,7 @@ CONF_DIR = os.path.join(os.path.dirname(__file__), '../config')
 APPLICATION_URLS = [
     (r"", root_handler.RootHandler, {'version': __version__}),
     (r"/capabilities", capabilities_handler.CapabilitiesHandler),
+    (r"/repositories/{repository_id}/initialise$", namespace_handler.NamespaceHandler),
     (r"/repositories/{repository_id}/assets/identifiers$", assets_handler.IdentifiersHandler),
     (r"/repositories/{repository_id}/assets/{entity_id}/ids$", assets_handler.AssetIDHandler),
     (r"/repositories/{repository_id}/assets$", assets_handler.AssetsHandler),

--- a/repository/controllers/base.py
+++ b/repository/controllers/base.py
@@ -14,7 +14,7 @@ from urllib import urlencode
 
 import tornado.httpclient
 from tornado.gen import coroutine, Return
-from tornado.options import options
+from tornado.options import options, define
 
 from koi.exceptions import HTTPError
 from koi.base import BaseHandler
@@ -24,6 +24,7 @@ from repository.models.framework.helper import PermissionException, ValidationEx
 
 from chub import API
 
+define("standalone", help='Run service in standalone mode', default=False, type=bool)
 
 class RepoBaseHandler(BaseHandler):
     token = None
@@ -127,9 +128,9 @@ class RepoBaseHandler(BaseHandler):
         repository_id = self.path_kwargs.get('repository_id')
 
         requested_access = self.endpoint_access(self.request.method)
-        use_oauth = getattr(options, 'use_oauth', None)
+        standalone = getattr(options, 'standalone', None)
 
-        if use_oauth and requested_access is not self.UNAUTHENTICATED_ACCESS:
+        if not standalone and requested_access is not self.UNAUTHENTICATED_ACCESS:
             token = self.request.headers.get('Authorization', '').split(' ')[-1]
             if token:
                 has_access = yield self.verify_repository_token(token, requested_access, repository_id)

--- a/repository/controllers/base.py
+++ b/repository/controllers/base.py
@@ -129,7 +129,7 @@ class RepoBaseHandler(BaseHandler):
         requested_access = self.endpoint_access(self.request.method)
         standalone = getattr(options, 'standalone', None)
 
-        if not standalone and requested_access is not self.UNAUTHENTICATED_ACCESS:
+        if requested_access is not self.UNAUTHENTICATED_ACCESS and not standalone:
             token = self.request.headers.get('Authorization', '').split(' ')[-1]
             if token:
                 has_access = yield self.verify_repository_token(token, requested_access, repository_id)
@@ -141,7 +141,7 @@ class RepoBaseHandler(BaseHandler):
                 msg = 'OAuth token not provided'
                 raise HTTPError(401, msg)
 
-        if repository_id:
+        if repository_id and not standalone:
             self.organisation_id = yield self.get_organisation_id(repository_id)
 
     def get_content_type(self):

--- a/repository/controllers/base.py
+++ b/repository/controllers/base.py
@@ -24,7 +24,6 @@ from repository.models.framework.helper import PermissionException, ValidationEx
 
 from chub import API
 
-define("standalone", help='Run service in standalone mode', default=False, type=bool)
 
 class RepoBaseHandler(BaseHandler):
     token = None

--- a/repository/controllers/namespace_handler.py
+++ b/repository/controllers/namespace_handler.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Open Permissions Platform Coalition
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Handlers for namespaces"""
+import logging
+from koi.exceptions import HTTPError
+from tornado.gen import coroutine
+import tornado.httpclient
+from .base import RepoBaseHandler
+from ..models.framework.db import create_namespace
+
+
+class NamespaceHandler(RepoBaseHandler):
+    """Handler to initialise namespace"""
+    @coroutine
+    def post(self, repository_id):
+        """
+        Initialise a namespace if it has not already been initialised
+
+        :param repository_id: id of repository/namespace
+        """
+        # If not running in standalone mode, the RepoBaseHandler will check to ensure repository id
+        # is already registered with the accounts service, and will raise a 404 if not.
+
+        try:
+            yield create_namespace(repository_id)
+        except tornado.httpclient.HTTPError as exc:
+            # Must be converted to a tornado.web.HTTPError for the server
+            # to handle it correctly
+            logging.exception(exc.message)
+
+            if exc.code == 409:
+                raise HTTPError(400, 'Namespace {} already exists'.format(repository_id))
+            else:
+                raise HTTPError(500, 'Internal Server Error')
+
+        self.finish({'status': 200})

--- a/repository/models/asset.py
+++ b/repository/models/asset.py
@@ -233,7 +233,11 @@ class Asset(Entity):
         assetids = get_asset_ids(payload, content_type)
         entity_ids = [x[u'entity_id'] for x in assetids]
         yield Entity.insert_timestamps(ids=entity_ids, repository=repository)
-        IOLoop.current().spawn_callback(partial(eval('send_notification'), repository))
+
+        # Send notification to index service if not in standalone mode
+        if not options.standalone:
+            IOLoop.current().spawn_callback(partial(eval('send_notification'), repository))
+
         raise Return(assetids)
 
 

--- a/repository/models/offer.py
+++ b/repository/models/offer.py
@@ -90,7 +90,7 @@ class Offer(Policy):
 
     @classmethod
     @gen.coroutine
-    def new_offer(cls, repository, offer, assigner, format="xml"):
+    def new_offer(cls, repository, offer, assigner=None, format="xml"):
         """
         Create a new offer.
 
@@ -127,9 +127,12 @@ class Offer(Policy):
         results = list(ng.query(query))
         offer_id = results[0][0]
 
-        # set assigner
-        party = yield Party.new_party(future_wrap(ng), assigner)
-        yield cls.set_attr(future_wrap(ng), offer_id, POLICY_ASSIGNER,  solve_ns(Party.normalise_id(party)))
+        # If assigner is provided, set as assigner in offer data.
+        # ( Assigner will not be provided if in standalone mode,
+        #   in which case we allow assigner to be included as part of input )
+        if assigner:
+            party = yield Party.new_party(future_wrap(ng), assigner)
+            yield cls.set_attr(future_wrap(ng), offer_id, POLICY_ASSIGNER,  solve_ns(Party.normalise_id(party)))
 
         rdfxml = ng.serialize()
         yield cls.store(repository, rdfxml)

--- a/tests/unit/controllers/test_base.py
+++ b/tests/unit/controllers/test_base.py
@@ -198,7 +198,7 @@ def test_prepare_no_repository_id(jwt, verify_repository_token, get_organisation
 
     verify_repository_token.return_value = make_future(True)
 
-    options.use_oauth = True
+    options.standalone = False
     handler = PartialMockedHandler()
     handler.request.headers = {'Authorization': 'Bearer token1234'}
     handler.path_kwargs = {}
@@ -234,7 +234,7 @@ def test_prepare_oauth_required_valid(jwt, verify_repository_token, get_organisa
 
     verify_repository_token.return_value = make_future(True)
     get_organisation_id.return_value = make_future('org1')
-    options.use_oauth = True
+    options.standalone = False
     handler = PartialMockedHandler()
     handler.request.headers = {'Authorization': 'Bearer token1234'}
 
@@ -268,7 +268,7 @@ def test_prepare_oauth_required_missing_bearer(jwt, verify_repository_token, get
     }
     verify_repository_token.return_value = make_future(True)
     get_organisation_id.return_value = make_future('org1')
-    options.use_oauth = True
+    options.standalone = False
     handler = PartialMockedHandler()
     handler.request.headers = {'Authorization': 'token1234'}
 
@@ -292,7 +292,7 @@ def test_prepare_oauth_required_missing_bearer(jwt, verify_repository_token, get
 @gen_test
 def test_prepare_oauth_required_invalid(verify_repository_token, get_organisation_id, options):
     verify_repository_token.return_value = make_future(False)
-    options.use_oauth = True
+    options.standalone = False
     handler = PartialMockedHandler()
     handler.request.headers = {'Authorization': 'Bearer token1234'}
 
@@ -309,7 +309,7 @@ def test_prepare_oauth_required_invalid(verify_repository_token, get_organisatio
 @patch('repository.controllers.base.RepoBaseHandler.verify_repository_token')
 @gen_test
 def test_prepare_oauth_required_missing_header(verify_repository_token, get_organisation_id, options):
-    options.use_oauth = True
+    options.standalone = False
     handler = PartialMockedHandler()
     handler.request.headers = {}
 
@@ -326,7 +326,7 @@ def test_prepare_oauth_required_missing_header(verify_repository_token, get_orga
 @patch('repository.controllers.base.RepoBaseHandler.verify_repository_token')
 @gen_test
 def test_prepare_oauth_required_unauthenticated_endpoint(verify_repository_token, get_organisation_id, options):
-    options.use_oauth = True
+    options.standalone = False
     handler = PartialMockedHandler()
     handler.METHOD_ACCESS = {
         'GET': handler.UNAUTHENTICATED_ACCESS
@@ -345,7 +345,7 @@ def test_prepare_oauth_required_unauthenticated_endpoint(verify_repository_token
 @patch('repository.controllers.base.RepoBaseHandler.verify_repository_token')
 @gen_test
 def test_prepare_oauth_not_required(verify_repository_token, get_organisation_id, options):
-    options.use_oauth = False
+    options.standalone = True
     handler = PartialMockedHandler()
     get_organisation_id.return_value = make_future('org1')
 

--- a/tests/unit/controllers/test_base.py
+++ b/tests/unit/controllers/test_base.py
@@ -344,16 +344,16 @@ def test_prepare_oauth_required_unauthenticated_endpoint(verify_repository_token
 @patch('repository.controllers.base.RepoBaseHandler.get_organisation_id')
 @patch('repository.controllers.base.RepoBaseHandler.verify_repository_token')
 @gen_test
-def test_prepare_oauth_not_required(verify_repository_token, get_organisation_id, options):
+def test_prepare_standalone_mode(verify_repository_token, get_organisation_id, options):
     options.standalone = True
     handler = PartialMockedHandler()
-    get_organisation_id.return_value = make_future('org1')
 
     yield handler.prepare()
 
     assert not verify_repository_token.called
-    get_organisation_id.assert_called_once_with('repo1')
+    assert not get_organisation_id.called
     assert handler.token is None
+    assert handler.organisation_id is None
 
 
 @pytest.mark.parametrize('content_type', RepoBaseHandler.ALLOWED_CONTENT_TYPES)

--- a/tests/unit/controllers/test_namespace_handler.py
+++ b/tests/unit/controllers/test_namespace_handler.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Open Permissions Platform Coalition
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import pytest
+from mock import MagicMock, patch
+
+from koi import exceptions
+from koi.test_helpers import make_future
+
+import tornado.httpclient
+from repository.controllers.namespace_handler import NamespaceHandler
+
+
+TEST_NAMESPACE = 'c8ab01'
+
+
+class PartialMockedHandler(NamespaceHandler):
+    def __init__(self):
+        super(PartialMockedHandler, self).__init__(application=MagicMock(), request=MagicMock())
+        self.finish = MagicMock()
+
+
+@patch('repository.controllers.namespace_handler.create_namespace', return_value = make_future(True))
+def test_namespace_handler_post(create_namespace):
+    handler = PartialMockedHandler()
+    handler.post(TEST_NAMESPACE).result()
+
+    create_namespace.assert_called_once_with(TEST_NAMESPACE)
+    handler.finish.assert_called_once_with({"status": 200})
+
+
+@patch('repository.controllers.namespace_handler.create_namespace', return_value = make_future(True))
+def test_namespace_handler_http_error(create_namespace):
+    create_namespace.side_effect = tornado.httpclient.HTTPError(404, "Error")
+
+    handler = PartialMockedHandler()
+    with pytest.raises(exceptions.HTTPError) as exc:
+        handler.post(TEST_NAMESPACE).result()
+
+    assert exc.value.status_code == 500
+
+
+@patch('repository.controllers.namespace_handler.create_namespace', return_value = make_future(True))
+def test_namespace_handler_http_conflict(create_namespace):
+    create_namespace.side_effect = tornado.httpclient.HTTPError(409, "Error")
+
+    handler = PartialMockedHandler()
+    with pytest.raises(exceptions.HTTPError) as exc:
+        handler.post(TEST_NAMESPACE).result()
+
+    assert exc.value.status_code == 400


### PR DESCRIPTION
Replace oauth flag in config with more generic 'standalone' flag. In standalone mode the repository service should: 
- Not perform oauth checks
- Not send notifications to index service
- Not set/override assigner on offer
- Not lazily initialise namespaces

New endpoint has been added to manually initialise namespaces.

Bamboo job: http://bamboo.digicat.io/browse/CHCL-MPT198-1
